### PR TITLE
🐛 Change peer dependency from `playwright` to `playwright-core`

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@percy/sdk-utils": "^1.0.0"
   },
   "peerDependencies": {
-    "playwright": ">=1"
+    "playwright-core": ">=1"
   },
   "devDependencies": {
     "@percy/core": "^1.1.2",
@@ -45,7 +45,6 @@
     "eslint-plugin-promise": "^5.1.0",
     "eslint-plugin-standard": "^5.0.0",
     "nyc": "^15.1.0",
-    "playwright": "^1.22.0",
     "tsd": "^0.20.0"
   }
 }


### PR DESCRIPTION
Setting `peerDependency` to `playwright` causes trouble for the clients that use `@playwright/test` instead of `playwright`, see https://github.com/microsoft/playwright/issues/14366. Changing the peer dependency to [`playwright-core`](https://www.npmjs.com/package/playwright-core) makes this work nicely for both clients that use `playwright` and `@playwright/test` as both of the packages depend on `playwright-core`.

Note that this change may break clients that didn't have `playwright` explicitly in their dependencies and relied it coming as a transitive dependency from @percy/playwright but such setup should already be considered a bug given that percy only has playwright as a peer dependency.