### PR TITLE
fixing vunerability `path-to-regexp`

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "playwright-core": ">=1"
   },
   "devDependencies": {
-    "@percy/cli": "^1.28.8",
+    "@percy/cli": "^1.30.2",
     "@playwright/test": "^1.24.2",
     "babel-eslint": "^10.1.0",
     "cross-env": "^7.0.2",
@@ -47,7 +47,7 @@
     "eslint-plugin-standard": "^5.0.0",
     "nyc": "^15.1.0",
     "playwright": "^1.24.2",
-    "sinon": "^18.0.0",
+    "sinon": "^18.0.1",
     "tsd": "^0.25.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -418,148 +418,149 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@percy/cli-app@1.28.7":
-  version "1.28.7"
-  resolved "https://registry.yarnpkg.com/@percy/cli-app/-/cli-app-1.28.7.tgz#0b77c98a6f0fc87321015b0b7709148719f23f4e"
-  integrity sha512-5Dgtx3m+eX2NPYrt11gOAhH0q4UYFORzOTkocELQZ6+9naKOi0PD9e9/T8A6yRQ5dbfMoNfi/xQ9tLoxCPcM5g==
+"@percy/cli-app@1.30.2":
+  version "1.30.2"
+  resolved "https://registry.yarnpkg.com/@percy/cli-app/-/cli-app-1.30.2.tgz#69e9447eea808f112cbf47031a85b67a0a880444"
+  integrity sha512-d9wYECnzwUfZbZaujTIKxgnMmt2HumW8aw442ddgcRyXfNT31MFyskUvHRPU8WQ7fW1xy8BQniwlWrbEO8zNOw==
   dependencies:
-    "@percy/cli-command" "1.28.7"
-    "@percy/cli-exec" "1.28.7"
+    "@percy/cli-command" "1.30.2"
+    "@percy/cli-exec" "1.30.2"
 
-"@percy/cli-build@1.28.7":
-  version "1.28.7"
-  resolved "https://registry.yarnpkg.com/@percy/cli-build/-/cli-build-1.28.7.tgz#8a7aa9ba464aefdf070d7bb013704273e350b4a4"
-  integrity sha512-LXDXbE3G994K1Wovivukjbzj7wqENPa/A3WvveVdLqfTLepTcJZ3LvPV79BsgJgIMN2vksaeCxwIgjMn1vT8mQ==
+"@percy/cli-build@1.30.2":
+  version "1.30.2"
+  resolved "https://registry.yarnpkg.com/@percy/cli-build/-/cli-build-1.30.2.tgz#270c87a68512910a410390c76010b3e645c71884"
+  integrity sha512-oiCF9eQRTQMofkF05gnBZ3FpP0rIihjy6l66KPZtM2xhzy4mybAGdvfLHKNdm5VF02TomgNEhTB0XiBq0cHoLw==
   dependencies:
-    "@percy/cli-command" "1.28.7"
+    "@percy/cli-command" "1.30.2"
 
-"@percy/cli-command@1.28.7":
-  version "1.28.7"
-  resolved "https://registry.yarnpkg.com/@percy/cli-command/-/cli-command-1.28.7.tgz#673b859fa4585ea72551a03fa82ba2dca900d14d"
-  integrity sha512-Rs66JVZLdb4D/+hPXNdd9Qi9+FA9xCgrzpmdKak8HzstcfsRdJ999J5exQZc7dM1N3Th76wrA5d4woCgDskYDQ==
+"@percy/cli-command@1.30.2":
+  version "1.30.2"
+  resolved "https://registry.yarnpkg.com/@percy/cli-command/-/cli-command-1.30.2.tgz#fc7e517d6cde74ba2a09262991217a0a7d03085e"
+  integrity sha512-RRXFkis/PGf+/51Zp/9WyOwBPbkt+nNDh0P7W9b6JuJPu5uKj7oveP2KU1q+vsBVmLwUaZnkBSUjrC4lRltnLw==
   dependencies:
-    "@percy/config" "1.28.7"
-    "@percy/core" "1.28.7"
-    "@percy/logger" "1.28.7"
+    "@percy/config" "1.30.2"
+    "@percy/core" "1.30.2"
+    "@percy/logger" "1.30.2"
 
-"@percy/cli-config@1.28.7":
-  version "1.28.7"
-  resolved "https://registry.yarnpkg.com/@percy/cli-config/-/cli-config-1.28.7.tgz#c3a4f11d4c23d4773c61c4835708429d35903280"
-  integrity sha512-26Wo9EYQt2uDROSjNyYMX8XuJ30IPIwR4JsNKO0DbQUBqq071to5AiaROXs2QLH0m2KGFyYavLxHJ54ZCDbMQQ==
+"@percy/cli-config@1.30.2":
+  version "1.30.2"
+  resolved "https://registry.yarnpkg.com/@percy/cli-config/-/cli-config-1.30.2.tgz#fc4c5efddbd8af020262a299a818ac420a03b45c"
+  integrity sha512-9k0NL2hC6V+Byz8ZeyjbpJIrdK1nYuvbO1+Bkalq8lCz4aGGf5HzxEwa16BOdiq+JfpThBYZeo7Gdr+VLuC5Iw==
   dependencies:
-    "@percy/cli-command" "1.28.7"
+    "@percy/cli-command" "1.30.2"
 
-"@percy/cli-exec@1.28.7":
-  version "1.28.7"
-  resolved "https://registry.yarnpkg.com/@percy/cli-exec/-/cli-exec-1.28.7.tgz#aae8b21b20736baf5d1bbca3d4fe3ef4ab59d480"
-  integrity sha512-0HEOmMNexRbn09Ju3Etd5agEhBtgqNrT3eiRMcX4ThbQgOFkAQIll6IFfVqafujJHNL1SF+HjcyZmyoEF9tJOw==
+"@percy/cli-exec@1.30.2":
+  version "1.30.2"
+  resolved "https://registry.yarnpkg.com/@percy/cli-exec/-/cli-exec-1.30.2.tgz#cd0927e3b168181e835151a782ecd76d179b32b7"
+  integrity sha512-Y+e2i3UDRz2pbmCmbXQ6LmfOnCnyvZotOzE/tKkFrgeMIkNVx9gg/UwSWYDzGOYBXc2FuiBPiXV3cYlDKo7f2Q==
   dependencies:
-    "@percy/cli-command" "1.28.7"
+    "@percy/cli-command" "1.30.2"
+    "@percy/logger" "1.30.2"
     cross-spawn "^7.0.3"
     which "^2.0.2"
 
-"@percy/cli-snapshot@1.28.7":
-  version "1.28.7"
-  resolved "https://registry.yarnpkg.com/@percy/cli-snapshot/-/cli-snapshot-1.28.7.tgz#0fd99733cb9fa2199133c0b429fb9fd310a6d733"
-  integrity sha512-nWk2/sjIh8Vy6+T7BNwSVdtXUdR0cYpXJrbO1hfxRB56pUf8KFcG7GqUzOZ7QDHqlyQGH/posAjAoPmy8okyAQ==
+"@percy/cli-snapshot@1.30.2":
+  version "1.30.2"
+  resolved "https://registry.yarnpkg.com/@percy/cli-snapshot/-/cli-snapshot-1.30.2.tgz#042b43e6d36241f606c92fc7d637f211f6d33683"
+  integrity sha512-S5JU7CkYmFcE2kKw2CFhgcX75aC04Hq57Z28SGNYnvgpmxG7wTDdPjiLQa/9jmmAQRK6J23EJS4/Fmk+JJT3sg==
   dependencies:
-    "@percy/cli-command" "1.28.7"
+    "@percy/cli-command" "1.30.2"
     yaml "^2.0.0"
 
-"@percy/cli-upload@1.28.7":
-  version "1.28.7"
-  resolved "https://registry.yarnpkg.com/@percy/cli-upload/-/cli-upload-1.28.7.tgz#ab8f178f0001ec5e66fc5bcade0efffcf5e5bd91"
-  integrity sha512-hcIe9RGHDk+G+lanlLy1IrDRgODsTYzjmtPex9wEg4yo/JzubVwkF3r/0iQuT+srkELKUcTSJ1iX7/d0kK61uQ==
+"@percy/cli-upload@1.30.2":
+  version "1.30.2"
+  resolved "https://registry.yarnpkg.com/@percy/cli-upload/-/cli-upload-1.30.2.tgz#e01747b62146b239096b484607664f16ff7ef909"
+  integrity sha512-4G7KYnpYAOUwCp5zPpHb2Z/IP6QfC0XMAKcx8wgzStKRrQA5sYAJxs00zNbcrKKfLgbRT4Z5fPultkSY9s8T0Q==
   dependencies:
-    "@percy/cli-command" "1.28.7"
+    "@percy/cli-command" "1.30.2"
     fast-glob "^3.2.11"
     image-size "^1.0.0"
 
-"@percy/cli@^1.28.2":
-  version "1.28.7"
-  resolved "https://registry.yarnpkg.com/@percy/cli/-/cli-1.28.7.tgz#4608d5347da6858d4f11720dc15947ee14d17024"
-  integrity sha512-FvvyTFTGuIiBsSs8epENGq2U62oKnzfXW6F80JFShaZ5ZjMc2t6riVq4EPEsBANstql+j4Y853tYe2aGVX9pbw==
+"@percy/cli@^1.30.2":
+  version "1.30.2"
+  resolved "https://registry.yarnpkg.com/@percy/cli/-/cli-1.30.2.tgz#b9b503bb559265767fb935b5a7a5e1b32e70757f"
+  integrity sha512-Yfk+wOOHu1d3Wh9x26UCcQWjdRoW3iIk6yja7TxQ8vipQkNU0SVDxDREDuLXAGsgKoNsjCWPATwXo16OfYLl6A==
   dependencies:
-    "@percy/cli-app" "1.28.7"
-    "@percy/cli-build" "1.28.7"
-    "@percy/cli-command" "1.28.7"
-    "@percy/cli-config" "1.28.7"
-    "@percy/cli-exec" "1.28.7"
-    "@percy/cli-snapshot" "1.28.7"
-    "@percy/cli-upload" "1.28.7"
-    "@percy/client" "1.28.7"
-    "@percy/logger" "1.28.7"
+    "@percy/cli-app" "1.30.2"
+    "@percy/cli-build" "1.30.2"
+    "@percy/cli-command" "1.30.2"
+    "@percy/cli-config" "1.30.2"
+    "@percy/cli-exec" "1.30.2"
+    "@percy/cli-snapshot" "1.30.2"
+    "@percy/cli-upload" "1.30.2"
+    "@percy/client" "1.30.2"
+    "@percy/logger" "1.30.2"
 
-"@percy/client@1.28.7":
-  version "1.28.7"
-  resolved "https://registry.yarnpkg.com/@percy/client/-/client-1.28.7.tgz#7baced7a2b2cb82de294f9943d749f8bc440e1f3"
-  integrity sha512-3ocKEej268Xj3q98seUi88mtFcTYNy3F/zMTwk+pdnoWc1QVOGsCQ3elIS2X35hhBFgYw2i1bbuzmt7UdOK79A==
+"@percy/client@1.30.2":
+  version "1.30.2"
+  resolved "https://registry.yarnpkg.com/@percy/client/-/client-1.30.2.tgz#c57c04b3a0ea94038ef506ec8f6f9ebc7e912476"
+  integrity sha512-C/J/oK0j8GytYezhr10n0BQZ5UmCWrmMQ5M2nNi5/aZgezUwJ4mInna2Yr5LYWoEIchXZSixOB+c9/DL4P6JdA==
   dependencies:
-    "@percy/env" "1.28.7"
-    "@percy/logger" "1.28.7"
+    "@percy/env" "1.30.2"
+    "@percy/logger" "1.30.2"
     pako "^2.1.0"
 
-"@percy/config@1.28.7":
-  version "1.28.7"
-  resolved "https://registry.yarnpkg.com/@percy/config/-/config-1.28.7.tgz#b304fd2bb8da08b05046605645583870d4a1887e"
-  integrity sha512-N8fZAj8ejgddxz4lzNIK9cCQdoIuISK7a/JyGAD5vY+CuZutCBM0zuN9g/Higv/LI78Sct69Qpik/+rLIyBZxA==
+"@percy/config@1.30.2":
+  version "1.30.2"
+  resolved "https://registry.yarnpkg.com/@percy/config/-/config-1.30.2.tgz#f6c995557d7aabd85c69c8c3e5270ebca9e2b918"
+  integrity sha512-QILMvIDpKHhtqCT1w3WI2YVl9vWH9BaZR0GwwHOWsE6C3lti8Jq2AzrrvRiD8a6OepUjKL7gaZRD0fFgE/CAAQ==
   dependencies:
-    "@percy/logger" "1.28.7"
+    "@percy/logger" "1.30.2"
     ajv "^8.6.2"
     cosmiconfig "^8.0.0"
     yaml "^2.0.0"
 
-"@percy/core@1.28.7":
-  version "1.28.7"
-  resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.28.7.tgz#7576ecf1f69b45e160c59bb5f8adbb8af139eb2d"
-  integrity sha512-OOTVMHU+0O7Qh3TIL21fxX9H5ctRWPIG03IJsFpIXIIh2Wni5nf8tSUWroFwSSneZihxaA8ETQxCtJXBVe+JUA==
+"@percy/core@1.30.2":
+  version "1.30.2"
+  resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.30.2.tgz#49420391f76cde85b09db423930476a3baa5b3c0"
+  integrity sha512-RkWvh2BujnAvU/qU0y8Tu0fxnMbDxTE1DOa06gTwhtggbelew7fHrLfwKXKCeM3v358mBs82XZoDmNhByMQY6w==
   dependencies:
-    "@percy/client" "1.28.7"
-    "@percy/config" "1.28.7"
-    "@percy/dom" "1.28.7"
-    "@percy/logger" "1.28.7"
-    "@percy/webdriver-utils" "1.28.7"
+    "@percy/client" "1.30.2"
+    "@percy/config" "1.30.2"
+    "@percy/dom" "1.30.2"
+    "@percy/logger" "1.30.2"
+    "@percy/webdriver-utils" "1.30.2"
     content-disposition "^0.5.4"
     cross-spawn "^7.0.3"
     extract-zip "^2.0.1"
     fast-glob "^3.2.11"
-    micromatch "^4.0.4"
+    micromatch "^4.0.8"
     mime-types "^2.1.34"
     pako "^2.1.0"
-    path-to-regexp "^6.2.0"
+    path-to-regexp "^6.3.0"
     rimraf "^3.0.2"
-    ws "^8.0.0"
+    ws "^8.17.1"
     yaml "^2.4.1"
 
-"@percy/dom@1.28.7":
-  version "1.28.7"
-  resolved "https://registry.yarnpkg.com/@percy/dom/-/dom-1.28.7.tgz#6d07e96ee630ac3762e1e94804d94a1d038f8558"
-  integrity sha512-aYm/xTqNWaLodRdmWqiA0zekaUMkE8boJ1ApljO8KTKihv7eJWpgSDJT7m73xOd/JAplER5LSGjrUpnWLOTDYQ==
+"@percy/dom@1.30.2":
+  version "1.30.2"
+  resolved "https://registry.yarnpkg.com/@percy/dom/-/dom-1.30.2.tgz#c4e81280ce4b64932af9934bcf8de6482cf3f33d"
+  integrity sha512-M6fid4Uw2f2cD9WB7SL3qqRm/s1EJScukPHRVhQnn83vsGzhqCyhbUkphktMMADI/sB+JOaxSJgkBel7C0JvXw==
 
-"@percy/env@1.28.7":
-  version "1.28.7"
-  resolved "https://registry.yarnpkg.com/@percy/env/-/env-1.28.7.tgz#3dc71ff9e30e53681618f8ab389721acc1f734a4"
-  integrity sha512-ExpCDSm2bMwTlF7LOuE6dDB0QFa2VzpuFF/t9O0TyUgBgaiDZzcdsMQrLxDlUbuqjA8vc+vo8931x0i2sN5LBQ==
+"@percy/env@1.30.2":
+  version "1.30.2"
+  resolved "https://registry.yarnpkg.com/@percy/env/-/env-1.30.2.tgz#0812fe90b24b33e551d2dd4230d23213fc4c74e2"
+  integrity sha512-OAy98K3GfI1WSPO57fb3FeeWOux5Sifm0r7VJLKUkRk+auAtiPa2XCXKHBapopnDiteqj63ZDfkHbvjVtNVa9g==
   dependencies:
-    "@percy/logger" "1.28.7"
+    "@percy/logger" "1.30.2"
 
-"@percy/logger@1.28.7":
-  version "1.28.7"
-  resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.28.7.tgz#3ef2e35cefdc717ace4918fb9e42ef6e60a4beb4"
-  integrity sha512-OktqjykPT3FMUKkwyafjQdRWMQ8jnXOOcSkvyVIT9P7cbU1USeRUWw8Z6+W1cLk50RdsimChnab6F/GRWRdBew==
+"@percy/logger@1.30.2":
+  version "1.30.2"
+  resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.30.2.tgz#3a75d802afbaf0dfedf65ebb9f4f3327692ee7c7"
+  integrity sha512-MQAxqp4RHwlemkgK7d5sjt0ePUKAKbgugmrzOuiI9KLTbeoZoGuxn9RbuNamAfHAUMNYZ8B7DGU4ID518vpP4Q==
 
-"@percy/sdk-utils@1.28.7":
-  version "1.28.7"
-  resolved "https://registry.yarnpkg.com/@percy/sdk-utils/-/sdk-utils-1.28.7.tgz#22393f76d69ffee2f4def79aa41f15a7369f7503"
-  integrity sha512-LIhfHnkcS0fyIdo3gvKn7rwodZjbEtyLkgiDRSRulcBOatI2mhn2Bh269sXXiiFTyAW2BDQjyE3DWc4hkGbsbQ==
+"@percy/sdk-utils@1.30.2":
+  version "1.30.2"
+  resolved "https://registry.yarnpkg.com/@percy/sdk-utils/-/sdk-utils-1.30.2.tgz#17db142526d8fb7ca8c5cfc892ecef4bdfe24aa7"
+  integrity sha512-EkWP6Qjj02uHYnpkq5BTOLqkpwzZGdJ6XfxiSAQ7/q8UQRGaAHQtJl1wTYan8yLOYisCQwVZRd3ev2UrhI6ERw==
 
-"@percy/webdriver-utils@1.28.7":
-  version "1.28.7"
-  resolved "https://registry.yarnpkg.com/@percy/webdriver-utils/-/webdriver-utils-1.28.7.tgz#b17573f8e42f2830c4ca95a388dcc41d9f8351b5"
-  integrity sha512-BviRMj/oHgdniHoz1nzInpIXl4JTk4vZ0+9azWntGCThITc/HhQE1sLDcHhZGYvviY+NQ4ofCcBSzZRu1z1GcQ==
+"@percy/webdriver-utils@1.30.2":
+  version "1.30.2"
+  resolved "https://registry.yarnpkg.com/@percy/webdriver-utils/-/webdriver-utils-1.30.2.tgz#bfffae8591228c2b7c78e9fbf970eed950dad281"
+  integrity sha512-MiUVBPnv2ajz/ih/LkCxGAXJsPl4PXSmb+WxbKzTIFE8WOkXJSpyEuueYAUk5vInLJoeZ5xyImr83zJ+Bx2Y4A==
   dependencies:
-    "@percy/config" "1.28.7"
-    "@percy/sdk-utils" "1.28.7"
+    "@percy/config" "1.30.2"
+    "@percy/sdk-utils" "1.30.2"
 
 "@playwright/test@^1.24.2":
   version "1.27.1"
@@ -583,7 +584,7 @@
   dependencies:
     type-detect "4.0.8"
 
-"@sinonjs/fake-timers@^11.2.2":
+"@sinonjs/fake-timers@11.2.2", "@sinonjs/fake-timers@^11.2.2":
   version "11.2.2"
   resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-11.2.2.tgz#50063cc3574f4a27bd8453180a04171c85cc9699"
   integrity sha512-G2piCSxQ7oWOxwGSAyFHfPIsyeJGXYtc6mFbnFA+kRXkiEnTl8c/8jul2S329iFBnDI9HGoeWWAZvuvOkZccgw==
@@ -813,6 +814,13 @@ braces@^3.0.1:
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
   dependencies:
     fill-range "^7.0.1"
+
+braces@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.3.tgz#490332f40919452272d55a8480adc0c441358789"
+  integrity sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==
+  dependencies:
+    fill-range "^7.1.1"
 
 browserslist@^4.17.5:
   version "4.19.1"
@@ -1414,6 +1422,13 @@ fill-range@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
   integrity sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
+  dependencies:
+    to-regex-range "^5.0.1"
+
+fill-range@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.1.1.tgz#44265d3cac07e3ea7dc247516380643754a05292"
+  integrity sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==
   dependencies:
     to-regex-range "^5.0.1"
 
@@ -2095,6 +2110,14 @@ micromatch@^4.0.4:
     braces "^3.0.1"
     picomatch "^2.2.3"
 
+micromatch@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
+  integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==
+  dependencies:
+    braces "^3.0.3"
+    picomatch "^2.3.1"
+
 mime-db@1.51.0:
   version "1.51.0"
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.51.0.tgz#d9ff62451859b18342d960850dc3cfb77e63fb0c"
@@ -2162,7 +2185,7 @@ nise@^6.0.0:
     "@sinonjs/fake-timers" "^11.2.2"
     "@sinonjs/text-encoding" "^0.7.2"
     just-extend "^6.2.0"
-    path-to-regexp "^6.2.1"
+    path-to-regexp "^6.3.0"
 
 node-preload@^0.2.1:
   version "0.2.1"
@@ -2379,15 +2402,10 @@ path-parse@^1.0.7:
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
   integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
-path-to-regexp@^6.2.0:
-  version "6.2.0"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.2.0.tgz#f7b3803336104c346889adece614669230645f38"
-  integrity sha512-f66KywYG6+43afgE/8j/GoiNyygk/bnoCbps++3ErRKsIYkGGupyv07R2Ok5m9i67Iqc+T2g1eAUGUPzWhYTyg==
-
-path-to-regexp@^6.2.1:
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.2.2.tgz#324377a83e5049cbecadc5554d6a63a9a4866b36"
-  integrity sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==
+path-to-regexp@^6.3.0:
+  version "6.3.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-6.3.0.tgz#2b6a26a337737a8e1416f9272ed0766b1c0389f4"
+  integrity sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==
 
 path-type@^4.0.0:
   version "4.0.0"
@@ -2408,6 +2426,11 @@ picomatch@^2.2.3:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.0.tgz#f1f061de8f6a4bf022892e2d128234fb98302972"
   integrity sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==
+
+picomatch@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
+  integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
 pkg-dir@^4.1.0:
   version "4.2.0"
@@ -2641,13 +2664,13 @@ signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.5.tgz#9e3e8cc0c75a99472b44321033a7702e7738252f"
   integrity sha512-KWcOiKeQj6ZyXx7zq4YxSMgHRlod4czeBQZrPb8OKcohcqAXShm7E20kEMle9WBt26hFcAf0qLOcp5zmY7kOqQ==
 
-sinon@^18.0.0:
-  version "18.0.0"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-18.0.0.tgz#69ca293dbc3e82590a8b0d46c97f63ebc1e5fc01"
-  integrity sha512-+dXDXzD1sBO6HlmZDd7mXZCR/y5ECiEiGCBSGuFD/kZ0bDTofPYc6JaeGmPSF+1j1MejGUWkORbYOLDyvqCWpA==
+sinon@^18.0.1:
+  version "18.0.1"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-18.0.1.tgz#464334cdfea2cddc5eda9a4ea7e2e3f0c7a91c5e"
+  integrity sha512-a2N2TDY1uGviajJ6r4D1CyRAkzE9NNVlYOV1wX5xQDuAk0ONgzgRl0EjCQuRCPxOwp13ghsMwt9Gdldujs39qw==
   dependencies:
     "@sinonjs/commons" "^3.0.1"
-    "@sinonjs/fake-timers" "^11.2.2"
+    "@sinonjs/fake-timers" "11.2.2"
     "@sinonjs/samsam" "^8.0.0"
     diff "^5.2.0"
     nise "^6.0.0"
@@ -2997,10 +3020,10 @@ write-file-atomic@^3.0.0:
     signal-exit "^3.0.2"
     typedarray-to-buffer "^3.1.5"
 
-ws@^8.0.0:
-  version "8.4.2"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-8.4.2.tgz#18e749868d8439f2268368829042894b6907aa0b"
-  integrity sha512-Kbk4Nxyq7/ZWqr/tarI9yIt/+iNNFOjBXEWgTb4ydaNHBNGgvf2QHbS9fdfsndfjFlFwEd4Al+mw83YkaD10ZA==
+ws@^8.17.1:
+  version "8.18.0"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.0.tgz#0d7505a6eafe2b0e712d232b42279f53bc289bbc"
+  integrity sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==
 
 y18n@^4.0.0:
   version "4.0.3"


### PR DESCRIPTION
fixing vunerability `path-to-regexp`
- updated it to ^6.3.0