### PR TITLE
[PER-5489] Added Support for capturing CORS iFrames

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,89 @@ const CLIENT_INFO = `${sdkPkg.name}/${sdkPkg.version}`;
 const ENV_INFO = `${playwrightPkg.name}/${playwrightPkg.version}`;
 const log = utils.logger('playwright');
 
+// This function is executed in the browser context to handle dynamic resources.
+const handleDynamicResources = async () => {
+  // Handle lazy-loaded images
+  document.querySelectorAll('img').forEach(img => {
+    const dataSrc = img.getAttribute('data-src');
+    if (dataSrc) {
+      img.src = dataSrc;
+    }
+  });
+
+  // Handle blob background images
+  const elements = Array.from(document.querySelectorAll('*'));
+  const promises = [];
+
+  for (const el of elements) {
+    const style = window.getComputedStyle(el);
+    const backgroundImage = style.getPropertyValue('background-image');
+
+    if (backgroundImage && backgroundImage.includes('blob:')) {
+      const blobUrlMatch = backgroundImage.match(/url\("?(blob:.+?)"?\)/);
+      if (blobUrlMatch && blobUrlMatch[1]) {
+        const blobUrl = blobUrlMatch[1];
+
+        const promise = fetch(blobUrl)
+          .then(res => res.blob())
+          .then(blob => new Promise((resolve, reject) => {
+            const reader = new FileReader();
+            reader.onloadend = () => {
+              el.style.backgroundImage = style.getPropertyValue('background-image').replace(blobUrl, reader.result);
+              resolve();
+            };
+            reader.onerror = reject;
+            reader.readAsDataURL(blob);
+          }))
+          .catch(err => {
+            // Log error in the browser console
+            console.error(`[percy] Could not convert blob URL ${blobUrl} to data URL:`, err);
+          });
+        promises.push(promise);
+      }
+    }
+  }
+  await Promise.all(promises);
+};
+
+// Processes a single cross-origin frame to capture its snapshot and resources.
+async function processFrame(page, frame, options, percyDOM) {
+  const frameUrl = frame.url();
+
+  // Execute pre-serialization transformations in the iframe
+  await frame.evaluate(handleDynamicResources);
+
+  const iframeSnapshot = await frame.evaluate((opts) => {
+    /* eslint-disable-next-line no-undef */
+    return PercyDOM.serialize(opts);
+  }, { ...options, enableJavascript: true });
+
+  // Create a new resource for the iframe's HTML
+  const iframeResource = {
+    url: frameUrl,
+    content: iframeSnapshot.html,
+    mimetype: 'text/html'
+  };
+
+  // Get the iframe's element data from the main page context
+  const iframeData = await page.evaluate((fUrl) => {
+    const iframes = Array.from(document.querySelectorAll('iframe'));
+    const matchingIframe = iframes.find(iframe => iframe.src.startsWith(fUrl));
+    if (matchingIframe) {
+      return {
+        percyElementId: matchingIframe.getAttribute('data-percy-element-id')
+      };
+    }
+  }, frameUrl);
+
+  return {
+    iframeData,
+    iframeResource,
+    iframeSnapshot,
+    frameUrl
+  };
+}
+
 // Take a DOM snapshot and post it to the snapshot endpoint
 const percySnapshot = async function(page, name, options) {
   if (!page) throw new Error('A Playwright `page` object is required.');
@@ -16,7 +99,11 @@ const percySnapshot = async function(page, name, options) {
 
   try {
     // Inject the DOM serialization script
-    await page.evaluate(await utils.fetchPercyDOM());
+    const percyDOM = await utils.fetchPercyDOM();
+    await page.evaluate(percyDOM);
+
+    // Execute pre-serialization transformations on the main page
+    await page.evaluate(handleDynamicResources);
 
     // Serialize and capture the DOM
     /* istanbul ignore next: no instrumenting injected code */
@@ -24,6 +111,37 @@ const percySnapshot = async function(page, name, options) {
       /* eslint-disable-next-line no-undef */
       return PercyDOM.serialize(options);
     }, options);
+
+    // Process CORS IFrames
+    const pageUrl = new URL(page.url());
+    const crossOriginFrames = page.frames()
+      .filter(frame => frame.url() !== 'about:blank' && new URL(frame.url()).origin !== pageUrl.origin);
+
+    // Inject Percy DOM into all cross-origin frames before processing them in parallel
+    await Promise.all(crossOriginFrames.map(frame => frame.evaluate(percyDOM)));
+
+    const processedFrames = await Promise.all(
+      crossOriginFrames.map(frame => processFrame(page, frame, options, percyDOM))
+    );
+
+    for (const { iframeData, iframeResource, iframeSnapshot, frameUrl } of processedFrames) {
+      // Add the iframe's own resources to the main snapshot
+      domSnapshot.resources.push(...iframeSnapshot.resources);
+      // Add the iframe HTML resource itself
+      domSnapshot.resources.push(iframeResource);
+
+      if (iframeData && iframeData.percyElementId) {
+        const regex = new RegExp(`(<iframe[^>]*data-percy-element-id=["']${iframeData.percyElementId}["'][^>]*>)`);
+        const match = domSnapshot.html.match(regex);
+
+        if (match) {
+          const iframeTag = match[1];
+          // Replace the original iframe tag with one that points to the new resource.
+          const newIframeTag = iframeTag.replace(/src="[^"]*"/i, `src="${frameUrl}"`);
+          domSnapshot.html = domSnapshot.html.replace(iframeTag, newIframeTag);
+        }
+      }
+    }
 
     domSnapshot.cookies = await page.context().cookies();
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@percy/playwright",
   "description": "Playwright client library for visual testing with Percy",
-  "version": "1.0.9",
+  "version": "1.0.10-alpha.0",
   "license": "MIT",
   "author": "Perceptual Inc.",
   "repository": "https://github.com/percy/percy-playwright",
@@ -29,7 +29,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "latest"
+    "tag": "alpha"
   },
   "peerDependencies": {
     "playwright-core": ">=1"


### PR DESCRIPTION
This pull request introduces improved handling for dynamic resources and cross-origin iframes in the Playwright Percy integration, along with a package version bump and publishing tag update. The main focus is on ensuring that lazy-loaded images and blob-based background images are properly captured, and that cross-origin iframe content is serialized and included in snapshots.

### Enhanced resource handling and iframe processing

* Added a new `handleDynamicResources` function to the browser context that processes lazy-loaded images and blob-based background images before DOM serialization, ensuring these resources are captured in snapshots.
* Updated the main snapshot flow to execute `handleDynamicResources` on both the main page and all cross-origin iframes prior to serialization.
* Added logic to inject the Percy DOM script into cross-origin iframes, serialize their content, and merge their resources into the main snapshot. Also, updated the HTML to reference the correct iframe resource URLs.

### Package management updates

* Bumped the package version in `package.json` from `1.0.9` to `1.0.10-alpha.0` to reflect new changes and indicate an alpha release.
* Changed the `publishConfig.tag` in `package.json` from `latest` to `alpha` to publish the package under the alpha tag.