### PR TITLE
fix: use named export for 'percyScreenshot'

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -7,7 +7,13 @@ export default function percySnapshot(
   options?: SnapshotOptions
 ): Promise<void>;
 
-export default function percyScreenshot(
+export function percyScreenshot(
+  page: Playwright.Page,
+  name: string,
+  options?: SnapshotOptions
+): Promise<void>;
+
+export function percySnapshot(
   page: Playwright.Page,
   name: string,
   options?: SnapshotOptions

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -19,14 +19,10 @@ expectError(percyScreenshot(page));
 expectError(percyScreenshot('Snapshot name'));
 
 expectType<Promise<void>>(percySnapshot(page, 'Snapshot name'));
-expectType<Promise<void>>(
-  percySnapshot(page, 'Snapshot name', { widths: [1000] }),
-);
+expectType<Promise<void>>(percySnapshot(page, 'Snapshot name', { widths: [1000] }));
 
 expectType<Promise<void>>(percyScreenshot(page, 'Snapshot name'));
-expectType<Promise<void>>(
-  percyScreenshot(page, 'Snapshot name', { widths: [1000] }),
-);
+expectType<Promise<void>>(percyScreenshot(page, 'Snapshot name', { widths: [1000] }));
 
 //@ts-expect-error
 expectError(percySnapshot(page, 'Snapshot name', { foo: 'bar' }));

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,22 +1,34 @@
 import { expectType, expectError } from 'tsd';
 import * as Playwright from 'playwright';
 import percySnapshot from '.';
-import percyScreenshot from '.';
+import { percyScreenshot } from '.';
 
 declare const page: Playwright.Page;
 
+//@ts-expect-error
 expectError(percySnapshot());
+//@ts-expect-error
 expectError(percySnapshot(page));
+//@ts-expect-error
 expectError(percySnapshot('Snapshot name'));
+//@ts-expect-error
 expectError(percyScreenshot());
+//@ts-expect-error
 expectError(percyScreenshot(page));
+//@ts-expect-error
 expectError(percyScreenshot('Snapshot name'));
 
 expectType<Promise<void>>(percySnapshot(page, 'Snapshot name'));
-expectType<Promise<void>>(percySnapshot(page, 'Snapshot name', { widths: [1000] }));
+expectType<Promise<void>>(
+  percySnapshot(page, 'Snapshot name', { widths: [1000] }),
+);
 
 expectType<Promise<void>>(percyScreenshot(page, 'Snapshot name'));
-expectType<Promise<void>>(percyScreenshot(page, 'Snapshot name', { widths: [1000] }));
+expectType<Promise<void>>(
+  percyScreenshot(page, 'Snapshot name', { widths: [1000] }),
+);
 
+//@ts-expect-error
 expectError(percySnapshot(page, 'Snapshot name', { foo: 'bar' }));
+//@ts-expect-error
 expectError(percyScreenshot(page, 'Snapshot name', { foo: 'bar' }));


### PR DESCRIPTION
Currently it's not possible to use ESM imports for `percyScreenshot`:

```
import percyScreenshot from '@percy/playwright';
```

Even if it compiles, `percySnapshot` will be used during runtime since the module exports both as default, which causes license issues etc. when tusing with Browserstack Automate.

This PR fixes it by using named export for `percyScreenshot` because a module can't have more than one default exported member. After this, the correct import would be:


```
import { percyScreenshot } from '@percy/playwright';
```