### PR TITLE
chore: release 1.1.1-beta.0 (PER-7348 readiness)

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "latest"
+    "tag": "beta"
   },
   "peerDependencies": {
     "playwright-core": ">=1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@percy/playwright",
   "description": "Playwright client library for visual testing with Percy",
-  "version": "1.1.0",
+  "version": "1.1.1-beta.0",
   "license": "MIT",
   "author": "Perceptual Inc.",
   "repository": "https://github.com/percy/percy-playwright",
@@ -35,7 +35,7 @@
     "playwright-core": ">=1"
   },
   "devDependencies": {
-    "@percy/cli": "1.31.10",
+    "@percy/cli": "^1.32.0-beta.4",
     "@playwright/test": "^1.24.2",
     "babel-eslint": "^10.1.0",
     "cross-env": "^7.0.2",


### PR DESCRIPTION
**Status: DRAFT — do not merge until `@percy/cli@1.32.0-beta.4` is published to npm.**

### Why

First beta cutting the **readiness gate** (`waitForReady` before serialize) merged in #610. Held until cli `1.32.0-beta.4` (with percy/cli#2247 fix) is published, because percy-playwright uses the `page.evaluate(string)` path — the same path that was affected by the *"Illegal return statement"* bug. Shipping a beta now against a buggy cli would deliver a no-op gate to users.

### Why no `@percy/sdk-utils` dep bump (unlike percy-puppeteer)

`@percy/playwright`'s `package.json` has no `dependencies` field. `@percy/sdk-utils` is resolved transitively through the user's installed `@percy/cli` at runtime, so the user's CLI choice determines which sdk-utils ships. The fix flows through automatically when users update to `@percy/cli@1.32.0-beta.4`.

### Fix path

1. ✅ percy/cli#2247 — fix `waitForReadyScript` (bare ternary expression, not top-level return).
2. ⏳ Publish `@percy/cli@1.32.0-beta.4` (master vbumped via #2252; awaits #2247 merge).
3. **➡️ This PR** — cut `@percy/playwright@1.1.1-beta.0` shipping the readiness feature.

### Diff
- `package.json` — `version: 1.1.0 → 1.1.1-beta.0`
- `package.json` — devDep `@percy/cli: 1.31.10 → ^1.32.0-beta.4` (so CI exercises the fixed sdk-utils)

No source code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)