### PR TITLE
chore: release 1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "beta"
+    "tag": "latest"
   },
   "peerDependencies": {
     "playwright-core": ">=1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@percy/playwright",
   "description": "Playwright client library for visual testing with Percy",
-  "version": "1.1.1-beta.2",
+  "version": "1.1.1",
   "license": "MIT",
   "author": "Perceptual Inc.",
   "repository": "https://github.com/percy/percy-playwright",


### PR DESCRIPTION
Promotes the PER-8053 config-merge work from `1.1.1-beta.2` to stable `1.1.1`. Config is deep-merged into serializeDOM (per-call priority); verified via the cross-SDK sanity sweep.

Note: a pre-staged **draft** `v1.1.1` release exists (no git tag yet) — publish/replace it at release time.