### PR TITLE
chore: release 1.1.2-beta.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@percy/playwright",
   "description": "Playwright client library for visual testing with Percy",
-  "version": "1.1.1",
+  "version": "1.1.2-beta.0",
   "license": "MIT",
   "author": "Perceptual Inc.",
   "repository": "https://github.com/percy/percy-playwright",
@@ -29,7 +29,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "latest"
+    "tag": "beta"
   },
   "peerDependencies": {
     "playwright-core": ">=1"


### PR DESCRIPTION
Version bump to **`1.1.2-beta.0`** (npm dist-tag: `beta` via publishConfig) for the Playwright `toHaveScreenshot()` drop-in beta (PER-8985).

**⚠️ Merge-order dependency:** this PR contains only the version bump. Merge **#640** (the drop-in feature) into master **before** merging this and publishing the GitHub Release — otherwise `1.1.2-beta.0` ships without the feature it exists for.

Prod-validated: web/app/automate established flows, automate local-browser guard, `playwright:setup-baseline` gates, and a real BrowserStack Automate session (Windows 11 / Chrome 150 — build 52443804, 2/2 screenshots posted).

Publish flow: merge #640 → merge this → publish a GitHub Release → the Release workflow ships `@percy/playwright@1.1.2-beta.0` under the `beta` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)