### PR TITLE
fix: run the release workflow on Node 18

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
-          node-version: 20
+          node-version: 18
           registry-url: 'https://registry.npmjs.org'
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
@@ -20,8 +20,8 @@ jobs:
       - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: v1/${{ runner.os }}/node-20/${{ hashFiles('**/yarn.lock') }}
-          restore-keys: v1/${{ runner.os }}/node-20/
+          key: v1/${{ runner.os }}/node-18/${{ hashFiles('**/yarn.lock') }}
+          restore-keys: v1/${{ runner.os }}/node-18/
       - run: yarn
       - run: npm publish
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
-          node-version: 14
+          node-version: 20
           registry-url: 'https://registry.npmjs.org'
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
@@ -20,8 +20,8 @@ jobs:
       - uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: v1/${{ runner.os }}/node-14/${{ hashFiles('**/yarn.lock') }}
-          restore-keys: v1/${{ runner.os }}/node-14/
+          key: v1/${{ runner.os }}/node-20/${{ hashFiles('**/yarn.lock') }}
+          restore-keys: v1/${{ runner.os }}/node-20/
       - run: yarn
       - run: npm publish
         env:


### PR DESCRIPTION
The v1.1.2-beta.0 release run [failed](https://github.com/percy/percy-playwright/actions/runs/30812019159): the drop-in raised the package `engines` floor to `node >=16`, and `yarn` on the release runner (Node 14) refuses to install:

```
error @percy/playwright@1.1.2-beta.0: The engine "node" is incompatible with this module. Expected version ">=16". Got "14.21.3"
```

Bumps the release workflow to **Node 18** — the minimum that satisfies every engine floor in the tree: our package needs `>=16`, but the `@playwright/test@1.60` devDependency needs `>=18`, so Node 16 would fail the same way with yarn blaming Playwright instead. Cache keys updated to match.

**Re-release steps after merging:** the existing `v1.1.2-beta.0` tag points at the pre-fix commit, so a re-run would still use the old workflow. Delete the release + tag, then re-publish targeting the fixed master (I'll handle it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
