### PR TITLE
chore: release 1.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@percy/playwright",
   "description": "Playwright client library for visual testing with Percy",
-  "version": "1.1.2-beta.0",
+  "version": "1.1.2",
   "license": "MIT",
   "author": "Perceptual Inc.",
   "repository": "https://github.com/percy/percy-playwright",
@@ -37,7 +37,7 @@
   },
   "publishConfig": {
     "access": "public",
-    "tag": "beta"
+    "tag": "latest"
   },
   "dependencies": {
     "@percy/sdk-utils": "^1.32.0"


### PR DESCRIPTION
Stable version bump to **`1.1.2`** (npm dist-tag: `latest` via publishConfig) — the GA release of the Playwright `toHaveScreenshot()` drop-in (PER-8985): #640 (drop-in incl. Percy on Automate dispatch) + #650 (Node 18 release workflow), beta-validated as `1.1.2-beta.0` across prod web/app/automate flows and a real BrowserStack session.

**⚠️ Pre-publish gate:** the `@playwright/test` compat sweep (1.49–1.59) is an open GA blocker — the declared peer floor is `>=1.49`, but the matcher injection is confirmed broken on 1.53 (assertions silently run native after a one-time warning) and 1.49–1.52 / 1.54–1.59 are untested. Before publishing this release, either the injection fix or a raised peer floor should land — otherwise GA ships with an overstated compat claim. Verified-good today: 1.60/1.61 (1.61 only for Percy on Automate).

Publish flow: merge → publish a GitHub Release `v1.1.2` → the Release workflow ships `@percy/playwright@1.1.2` under `latest`. The stable version also dissolves the beta-only npm `overrides`/`--legacy-peer-deps` install caveat (the peer range accepts 1.32.6).

🤖 Generated with [Claude Code](https://claude.com/claude-code)